### PR TITLE
feat: use constructed style first

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -114,7 +114,7 @@ export function customElement(
 
         if (shadowRoot) {
           // Create Css
-          if (typeof CSSStyleSheet !== 'undefined' && shadowRoot.adoptedStyleSheets) {
+          if (typeof CSSStyleSheet === "function" && shadowRoot.adoptedStyleSheets) {
             // Use constructed style first
             const sheet = new CSSStyleSheet();
             sheet.replaceSync(style);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -114,7 +114,7 @@ export function customElement(
 
         if (shadowRoot) {
           // Create Css
-          if (CSSStyleSheet && shadowRoot.adoptedStyleSheets) {
+          if (typeof CSSStyleSheet !== 'undefined' && shadowRoot.adoptedStyleSheets) {
             // Use constructed style first
             const sheet = new CSSStyleSheet();
             sheet.replaceSync(style);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -114,9 +114,17 @@ export function customElement(
 
         if (shadowRoot) {
           // Create Css
-          const styleEl = document.createElement("style");
-          styleEl.innerHTML = style;
-          shadowRoot.append(styleEl);
+          if (CSSStyleSheet && shadowRoot.adoptedStyleSheets) {
+            // Use constructed style first
+            const sheet = new CSSStyleSheet();
+            sheet.replaceSync(style);
+            shadowRoot.adoptedStyleSheets = [sheet];
+          } else {
+            // Fallback
+            const styleEl = document.createElement("style");
+            styleEl.innerHTML = style;
+            shadowRoot.append(styleEl);
+          }
         }
 
         /**


### PR DESCRIPTION
优先采取 结构化的样式 constructed style。这样组件得到的 dom 树没有 style 节点的入侵，渲染的结果与 JSX 一模一样（降低心智负担）。而且方便将来共享相同的样式，父组件可以将它的公共样式（大量）传递下去。